### PR TITLE
Add a Python notebook for Google Colab setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ source venv/bin/activate  # Unix
 python agents/shopping_agent.py
 ```
 
+## Setting up the Python Notebook in Google Colab
+
+You can set up and run the Steel LangChain example notebook in Google Colab with one click. This notebook includes examples for testing the loader and running web and shopping agents.
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/rezapex/steel-langchain/blob/main/notebooks/steel_langchain_example.ipynb)
+
+### Instructions for Running the Notebook
+
+1. Click the "Open In Colab" button above to open the notebook in Google Colab.
+2. Follow the instructions in the notebook to install the required packages and set up the environment variables.
+3. Run the cells to test the loader and execute the agent examples.
+
 ## Usage
 
 ### Basic Web Loading

--- a/notebooks/steel_langchain_example.ipynb
+++ b/notebooks/steel_langchain_example.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Steel LangChain Example Notebook\n",
+    "\n",
+    "This notebook demonstrates how to set up and use the Steel LangChain integration for web automation tasks.\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "First, we need to install the required packages and set up the environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install required packages\n",
+    "!pip install -q langchain-core langchain-community langchain-openai steel-sdk playwright python-dotenv\n",
+    "\n",
+    "# Install Playwright browsers\n",
+    "!playwright install"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we need to set up the environment variables. You can either set them directly in the notebook or use a `.env` file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set environment variables\n",
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# Load environment variables from .env file\n",
+    "load_dotenv()\n",
+    "\n",
+    "# Set environment variables directly (optional)\n",
+    "os.environ['STEEL_API_KEY'] = 'your_steel_api_key_here'\n",
+    "os.environ['OPENAI_API_KEY'] = 'your_openai_api_key_here'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Testing the Loader\n",
+    "\n",
+    "Let's test the Steel Web Loader by loading a web page and displaying the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from steel_langchain import SteelWebLoader\n",
+    "\n",
+    "# Initialize loader\n",
+    "loader = SteelWebLoader(\n",
+    "    urls=[\"https://example.com\"],\n",
+    "    extract_strategy=\"text\"\n",
+    ")\n",
+    "\n",
+    "# Load webpage\n",
+    "documents = await loader.load()\n",
+    "\n",
+    "# Display content\n",
+    "print(documents[0].page_content)\n",
+    "print(documents[0].metadata)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running Agent Examples\n",
+    "\n",
+    "Now, let's create and run examples for the web and shopping agents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from agents.web_agent import create_web_agent\n",
+    "from agents.shopping_agent import create_shopping_agent\n",
+    "\n",
+    "# Create web browsing agent\n",
+    "web_agent = create_web_agent()\n",
+    "\n",
+    "# Run a web task\n",
+    "web_result = web_agent.invoke({\n",
+    "    \"input\": \"What is the main content of https://example.com?\"\n",
+    "})\n",
+    "\n",
+    "# Display web agent result\n",
+    "print(web_result['output'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create shopping agent\n",
+    "shopping_agent = create_shopping_agent()\n",
+    "\n",
+    "# Run a shopping task\n",
+    "shopping_result = shopping_agent.invoke({\n",
+    "    \"input\": \"Find me a good laptop under $1000\"\n",
+    "})\n",
+    "\n",
+    "# Display shopping agent result\n",
+    "print(shopping_result['output'])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Add a Python notebook for Google Colab setup and update README.md.

* **New Notebook**: 
  - Add `notebooks/steel_langchain_example.ipynb` with sections for setting up the environment, testing the loader, and running agent examples.
  - Include code cells for installing required packages, setting environment variables, testing the loader, and running web and shopping agents.

* **README.md Update**:
  - Add a new section for setting up the Python notebook in Google Colab.
  - Provide a link to the new Python notebook for one-click setup in Google Colab.
  - Include instructions for running the notebook and setting environment variables.

